### PR TITLE
Fixes some issues with authentication against erchef

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -19,9 +19,8 @@ import (
 )
 
 var testRequiredHeaders = []string{
-	"Accept",
 	"X-Ops-Timestamp",
-	"X-Ops-Userid",
+	"X-Ops-UserId",
 	"X-Ops-Sign",
 	"X-Ops-Content-Hash",
 	"X-Ops-Authorization-1",


### PR DESCRIPTION
I brought privateEncrypt in from chef-golang to fix a problem with signing with SignPKCS1v15.

Also:
- Including the right set of headers for erchef (as of 11.1.3-1).
- Fixing a case problem with X-Ops-UserId.
- Removes a trailing \n from the signed content, which erchef gets upset about.
