### PR TITLE
HTTP Tests: Fix authentication related failures

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -120,14 +120,3 @@ func base64BlockEncode(content []byte, limit int) []string {
 
 	return resultSlice
 }
-
-func publicDecrypt(pubKey *rsa.PublicKey, data []byte) ([]byte, error) {
-	c := new(big.Int)
-	m := new(big.Int)
-	m.SetBytes(data)
-	e := big.NewInt(int64(pubKey.E))
-	c.Exp(m, e, pubKey.N)
-	out := c.Bytes()
-
-	return out, nil
-}

--- a/http_test.go
+++ b/http_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"crypto/rsa"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	. "github.com/ctdk/goiardi/chefcrypto"
 	. "github.com/smartystreets/goconvey/convey"
 	"io"
 	"net/http"
@@ -276,19 +276,9 @@ func checkHeader(rw http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(rw, sherr.Error())
 	}
 
-	// signedHeaders are base64 encoded still, we'll need to
-	// Decode them
-	_, err := base64.StdEncoding.DecodeString(signedHeaders)
+	_, err := HeaderDecrypt(publicKey, signedHeaders)
 	if err != nil {
-		fmt.Fprintf(rw, "Unable to decode signed headers "+err.Error())
-	}
-
-	headToCheck := assembleHeaderToCheck(req)
-	pubKey, err := publicKeyFromString([]byte(publicKey))
-
-	_, err = publicDecrypt(pubKey, []byte(headToCheck))
-	if err != nil {
-		fmt.Fprintf(rw, "Unable to publicDecrypt headers")
+		fmt.Fprintf(rw, "unexpected header decryption error '%s'", err)
 	}
 }
 


### PR DESCRIPTION
- Add new keys with ``
- Add publicDecrypt from Goiardi
- General test updates for reverted behavior.
- Rip out VerifyPKCS1v15 validation mechanism.
