### PR TITLE
Add ACLService for modifying ACLs

### DIFF
--- a/acl.go
+++ b/acl.go
@@ -1,0 +1,60 @@
+package chef
+
+import "fmt"
+
+type ACLService struct {
+	client *Client
+}
+
+// ACL represents the native Go version of the deserialized ACL type
+type ACL map[string]ACLitems
+
+// ACLitems
+type ACLitems struct {
+	Groups ACLitem `json:"groups"`
+	Actors ACLitem `json:"actors"`
+}
+
+// ACLitem
+type ACLitem []string
+
+var DefaultACLs = [5]string{
+	"create",
+	"read",
+	"update",
+	"delete",
+	"grant",
+}
+
+func NewACL(acltype string, actors, groups ACLitem) (acl *ACL) {
+	acl = &ACL{
+		acltype: ACLitems{
+			Actors: actors,
+			Groups: groups,
+		},
+	}
+	return
+}
+
+// Get gets an ACL from the Chef server.
+//
+// Chef API docs: lol
+func (a *ACLService) Get(subkind string, name string) (acl ACL, err error) {
+	url := fmt.Sprintf("%s/%s/_acl", subkind, name)
+	err = a.client.magicRequestDecoder("GET", url, nil, &acl)
+	return
+}
+
+// Put updates an ACL on the Chef server.
+//
+// Chef API docs: rofl
+func (a *ACLService) Put(subkind, name string, acltype string, item *ACL) (err error) {
+	url := fmt.Sprintf("%s/%s/_acl/%s", subkind, name, acltype)
+	body, err := JSONReader(item)
+	if err != nil {
+		return
+	}
+
+	err = a.client.magicRequestDecoder("PUT", url, body, nil)
+	return
+}

--- a/acl.go
+++ b/acl.go
@@ -18,14 +18,6 @@ type ACLitems struct {
 // ACLitem
 type ACLitem []string
 
-var DefaultACLs = [5]string{
-	"create",
-	"read",
-	"update",
-	"delete",
-	"grant",
-}
-
 func NewACL(acltype string, actors, groups ACLitem) (acl *ACL) {
 	acl = &ACL{
 		acltype: ACLitems{

--- a/acl_test.go
+++ b/acl_test.go
@@ -1,0 +1,102 @@
+package chef
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestACLService_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/nodes/hostname/_acl", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{
+      "create": {
+        "actors": [
+          "hostname",
+          "pivotal"
+        ],
+        "groups": [
+          "clients",
+          "users",
+          "admins"
+        ]
+      },
+      "read": {
+        "actors": [
+          "hostname",
+          "pivotal"
+        ],
+        "groups": [
+          "clients",
+          "users",
+          "admins"
+        ]
+      },
+      "update": {
+        "actors": [
+          "hostname",
+          "pivotal"
+        ],
+        "groups": [
+          "users",
+          "admins"
+        ]
+      },
+      "delete": {
+        "actors": [
+          "hostname",
+          "pivotal"
+        ],
+        "groups": [
+          "users",
+          "admins"
+        ]
+      },
+      "grant": {
+        "actors": [
+          "hostname",
+          "pivotal"
+        ],
+        "groups": [
+          "admins"
+        ]
+      }
+    }
+    `)
+	})
+
+	acl, err := client.ACLs.Get("nodes", "hostname")
+	if err != nil {
+		t.Errorf("ACL.Get returned error: %v", err)
+	}
+
+	want := ACL{
+		"create": ACLitems{Groups: []string{"clients", "users", "admins"}, Actors: []string{"hostname", "pivotal"}},
+		"read":   ACLitems{Groups: []string{"clients", "users", "admins"}, Actors: []string{"hostname", "pivotal"}},
+		"update": ACLitems{Groups: []string{"users", "admins"}, Actors: []string{"hostname", "pivotal"}},
+		"delete": ACLitems{Groups: []string{"users", "admins"}, Actors: []string{"hostname", "pivotal"}},
+		"grant":  ACLitems{Groups: []string{"admins"}, Actors: []string{"hostname", "pivotal"}},
+	}
+
+	if !reflect.DeepEqual(acl, want) {
+		t.Errorf("ACL.Get returned %+v, want %+v", acl, want)
+	}
+}
+
+func TestACLService_Put(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/nodes/hostname/_acl/create", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, ``)
+	})
+
+	acl := NewACL("create", []string{"pivotal"}, []string{"admins"})
+	err := client.ACLs.Put("nodes", "hostname", "create", acl)
+	if err != nil {
+		t.Errorf("ACL.Put returned error: %v", err)
+	}
+}

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,9 @@ go get -u github.com/ctdk/goiardi/authentication
 go get -u github.com/davecgh/go-spew/spew
 go get -u github.com/smartystreets/goconvey/convey
 
+# go test -coverprofile=coverage dependency
+go get -u code.google.com/p/go.tools/cmd/cover
+
 # Overwrite the coverage file
 go test -coverprofile=coverage
 

--- a/http.go
+++ b/http.go
@@ -39,6 +39,7 @@ type Client struct {
 	BaseURL *url.URL
 	client  *http.Client
 
+	ACLs         *ACLService
 	Cookbooks    *CookbookService
 	DataBags     *DataBagService
 	Environments *EnvironmentService
@@ -131,6 +132,7 @@ func NewClient(cfg *Config) (*Client, error) {
 		client:  &http.Client{Transport: tr},
 		BaseURL: baseUrl,
 	}
+	c.ACLs = &ACLService{client: c}
 	c.Cookbooks = &CookbookService{client: c}
 	c.DataBags = &DataBagService{client: c}
 	c.Environments = &EnvironmentService{client: c}

--- a/http.go
+++ b/http.go
@@ -100,6 +100,9 @@ func (body *Body) Hash() (h string) {
 
 // ContentType returns the content-type string of Body as detected by http.DetectContentType()
 func (body *Body) ContentType() string {
+	if json.Unmarshal(body.Buffer().Bytes(), &struct{}{}) == nil {
+		return "application/json"
+	}
 	return http.DetectContentType(body.Buffer().Bytes())
 }
 


### PR DESCRIPTION
The client can now modify ACLs on nodes, cookbooks, and other undocumented things with ACLs.