### PR TITLE
Adding a configuration option to set an http timeout on client requests

### DIFF
--- a/http.go
+++ b/http.go
@@ -62,6 +62,9 @@ type Config struct {
 
 	// When set to false (default) this will enable SSL Cert Verification. If you need to disable Cert Verification set to true
 	SkipSSL bool
+
+	// Time to wait in seconds before giving up on a request to the server
+	Timeout time.Duration
 }
 
 /*
@@ -132,7 +135,10 @@ func NewClient(cfg *Config) (*Client, error) {
 			PrivateKey: pk,
 			ClientName: cfg.Name,
 		},
-		client:  &http.Client{Transport: tr},
+		client: &http.Client{
+			Transport: tr,
+			Timeout:   cfg.Timeout * time.Second,
+		},
 		BaseURL: baseUrl,
 	}
 	c.ACLs = &ACLService{client: c}


### PR DESCRIPTION
Because sometimes you don't want to wait forever