### PR TITLE
Add endpoint to get all recipes from all cookbooks

### DIFF
--- a/cookbook.go
+++ b/cookbook.go
@@ -20,6 +20,10 @@ type CookbookItem struct {
 // http://docs.opscode.com/api_chef_server.html#cookbooks
 type CookbookListResult map[string]CookbookVersions
 
+// CookbookRecipesResult is the summary info returned by chef-api when listing
+// http://docs.opscode.com/api_chef_server.html#cookbooks-recipes
+type CookbookRecipesResult []string
+
 // CookbookVersions is the data container returned from the chef server when listing all cookbooks
 type CookbookVersions struct {
 	Url      string            `json:"url,omitempty"`
@@ -127,6 +131,14 @@ func (c *CookbookService) GetVersion(name, version string) (data Cookbook, err e
 //   Chef API docs: http://docs.opscode.com/api_chef_server.html#id2
 func (c *CookbookService) ListAvailableVersions(numVersions string) (data CookbookListResult, err error) {
 	path := versionParams("cookbooks", numVersions)
+	err = c.client.magicRequestDecoder("GET", path, nil, &data)
+	return
+}
+
+// ListAllRecipes lists the names of all recipes in the most recent cookbook versions
+//   Chef API docs: https://docs.chef.io/api_chef_server.html#id31
+func (c *CookbookService) ListAllRecipes() (data CookbookRecipesResult, err error) {
+	path := "cookbooks/_recipes"
 	err = c.client.magicRequestDecoder("GET", path, nil, &data)
 	return
 }

--- a/cookbook_test.go
+++ b/cookbook_test.go
@@ -135,5 +135,27 @@ func TestCookBookGetAvailableVersions(t *testing.T) {
 		t.Error(err)
 	}
 	fmt.Println(data)
+}
 
+func TestCookBookListAllRecipes(t *testing.T) {
+	setup()
+	defer teardown()
+
+	cookbookRecipesJSON := `
+	[
+	  "apache2",
+	  "apache2::mod_access_compat",
+	  "apache2::mod_actions",
+	  "apache2::mod_alias"
+	]`
+
+	mux.HandleFunc("/cookbooks/_recipes", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, cookbookRecipesJSON)
+	})
+
+	data, err := client.Cookbooks.ListAllRecipes()
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println(data)
 }


### PR DESCRIPTION
This is an existing Chef Server API endpoint, but it was not yet available using this package...

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/go-chef/chef/73)
<!-- Reviewable:end -->
