### PR TITLE
Avoid sending "null"s for unused Node attributes.

### DIFF
--- a/node.go
+++ b/node.go
@@ -9,14 +9,14 @@ type NodeService struct {
 // Node represents the native Go version of the deserialized Node type
 type Node struct {
 	Name                string                 `json:"name"`
-	Environment         string                 `json:"chef_environment"`
-	ChefType            string                 `json:"chef_type"`
-	AutomaticAttributes map[string]interface{} `json:"automatic"`
-	NormalAttributes    map[string]interface{} `json:"normal"`
-	DefaultAttributes   map[string]interface{} `json:"default"`
-	OverrideAttributes  map[string]interface{} `json:"override"`
-	JsonClass           string                 `json:"json_class"`
-	RunList             []string               `json:"run_list"`
+	Environment         string                 `json:"chef_environment,omitempty"`
+	ChefType            string                 `json:"chef_type,omitempty"`
+	AutomaticAttributes map[string]interface{} `json:"automatic,omitempty"`
+	NormalAttributes    map[string]interface{} `json:"normal,omitempty"`
+	DefaultAttributes   map[string]interface{} `json:"default,omitempty"`
+	OverrideAttributes  map[string]interface{} `json:"override,omitempty"`
+	JsonClass           string                 `json:"json_class,omitempty"`
+	RunList             []string               `json:"run_list,omitempty"`
 }
 
 type NodeResult struct {


### PR DESCRIPTION
Per the API doc for Node POST (https://docs.chef.io/api_chef_server.html#id59), anything but "name" is optional.
Otherwise, we send null's and Chef spits back JSON type errors (at least Chef Server 12.7 does):
```
2016-06-21T22:10:07Z erchef@127.0.0.1 method=POST; path=/organizations/test/nodes; status=400; req_id=g3IAA2QAEGVyY2hlZkAxMjcuMC4wLjEBAAC/OwAAAAIAAAAA; org_name=test; msg={ej_invalid,json_type,<<"normal">>,null,null,object,undefined}; couchdb_groups=false; couchdb_organizations=false; couchdb_containers=false; couchdb_acls=false; 503_mode=false; couchdb_associations=false; couchdb_association_requests=false; req_time=1; rdbms_time=0; rdbms_count=1; user=test; req_api_version=1;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-chef/chef/84)
<!-- Reviewable:end -->
