### PR TITLE
point all API links to docs.chef.io

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,7 +43,7 @@ func (c ApiClientListResult) String() (out string) {
 
 // List lists the clients in the Chef server.
 //
-// Chef API docs: https://docs.chef.io/api_chef_server.html#id13
+// Chef API docs: https://docs.chef.io/api_chef_server.html#clients
 func (e *ApiClientService) List() (data ApiClientListResult, err error) {
 	err = e.client.magicRequestDecoder("GET", "clients", nil, &data)
 	return
@@ -51,7 +51,7 @@ func (e *ApiClientService) List() (data ApiClientListResult, err error) {
 
 // Get gets a client from the Chef server.
 //
-// Chef API docs: https://docs.chef.io/api_chef_server.html#id16
+// Chef API docs: https://docs.chef.io/api_chef_server.html#clients-name
 func (e *ApiClientService) Get(name string) (client ApiClient, err error) {
 	url := fmt.Sprintf("clients/%s", name)
 	err = e.client.magicRequestDecoder("GET", url, nil, &client)
@@ -60,7 +60,7 @@ func (e *ApiClientService) Get(name string) (client ApiClient, err error) {
 
 // Create makes a Client on the chef server
 //
-// Chef API docs: https://docs.chef.io/api_chef_server.html#id14
+// Chef API docs: https://docs.chef.io/api_chef_server.html#clients
 func (e *ApiClientService) Create(clientName string, admin bool) (data *ApiClientCreateResult, err error) {
 	post := ApiNewClient{
 		Name:  clientName,
@@ -77,11 +77,11 @@ func (e *ApiClientService) Create(clientName string, admin bool) (data *ApiClien
 
 // Put updates a client on the Chef server.
 //
-// Chef API docs: https://docs.chef.io/api_chef_server.html#id17
+// Chef API docs: https://docs.chef.io/api_chef_server.html#clients-name
 
 // Delete removes a client on the Chef server
 //
-// Chef API docs: https://docs.chef.io/api_chef_server.html#id15
+// Chef API docs: https://docs.chef.io/api_chef_server.html#clients-name
 func (e *ApiClientService) Delete(name string) (err error) {
 	err = e.client.magicRequestDecoder("DELETE", "clients/"+name, nil, nil)
 	return

--- a/cookbook.go
+++ b/cookbook.go
@@ -120,7 +120,7 @@ func (c *CookbookService) GetAvailableVersions(name, numVersions string) (data C
 // GetVersion fetches a specific version of a cookbooks data from the server api
 //   GET /cookbook/foo/1.2.3
 //   GET /cookbook/foo/_latest
-//   Chef API docs: http://docs.opscode.com/api_chef_server.html#id5
+//   Chef API docs: https://docs.chef.io/api_chef_server.html#cookbooks-name-version
 func (c *CookbookService) GetVersion(name, version string) (data Cookbook, err error) {
 	url := fmt.Sprintf("cookbooks/%s/%s", name, version)
 	c.client.magicRequestDecoder("GET", url, nil, &data)
@@ -128,7 +128,7 @@ func (c *CookbookService) GetVersion(name, version string) (data Cookbook, err e
 }
 
 // ListVersions lists the cookbooks available on the server limited to numVersions
-//   Chef API docs: http://docs.opscode.com/api_chef_server.html#id2
+//   Chef API docs: https://docs.chef.io/api_chef_server.html#cookbooks-name
 func (c *CookbookService) ListAvailableVersions(numVersions string) (data CookbookListResult, err error) {
 	path := versionParams("cookbooks", numVersions)
 	err = c.client.magicRequestDecoder("GET", path, nil, &data)
@@ -136,7 +136,7 @@ func (c *CookbookService) ListAvailableVersions(numVersions string) (data Cookbo
 }
 
 // ListAllRecipes lists the names of all recipes in the most recent cookbook versions
-//   Chef API docs: https://docs.chef.io/api_chef_server.html#id31
+//   Chef API docs: https://docs.chef.io/api_chef_server.html#cookbooks-recipes
 func (c *CookbookService) ListAllRecipes() (data CookbookRecipesResult, err error) {
 	path := "cookbooks/_recipes"
 	err = c.client.magicRequestDecoder("GET", path, nil, &data)

--- a/environment.go
+++ b/environment.go
@@ -46,7 +46,7 @@ func (e EnvironmentResult) String() (out string) {
 
 // List lists the environments in the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id14
+// Chef API docs: https://docs.chef.io/api_chef_server.html#environments
 func (e *EnvironmentService) List() (data *EnvironmentResult, err error) {
 	err = e.client.magicRequestDecoder("GET", "environments", nil, &data)
 	return
@@ -54,7 +54,7 @@ func (e *EnvironmentService) List() (data *EnvironmentResult, err error) {
 
 // Create an environment in the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id15
+// Chef API docs: https://docs.chef.io/api_chef_server.html#environments
 func (e *EnvironmentService) Create(environment *Environment) (data *EnvironmentResult, err error) {
 	body, err := JSONReader(environment)
 	if err != nil {
@@ -67,11 +67,11 @@ func (e *EnvironmentService) Create(environment *Environment) (data *Environment
 
 // Delete an environment from the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id16
+// Chef API docs: https://docs.chef.io/api_chef_server.html#environments-name
 
 // Get gets an environment from the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id17
+// Chef API docs: https://docs.chef.io/api_chef_server.html#environments-name
 func (e *EnvironmentService) Get(name string) (data *Environment, err error) {
 	path := fmt.Sprintf("environments/%s", name)
 	err = e.client.magicRequestDecoder("GET", path, nil, &data)
@@ -80,7 +80,7 @@ func (e *EnvironmentService) Get(name string) (data *Environment, err error) {
 
 // Write an environment to the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id18
+// Chef API docs: https://docs.chef.io/api_chef_server.html#environments-name
 func (e *EnvironmentService) Put(environment *Environment) (data *Environment, err error) {
 	path := fmt.Sprintf("environments/%s", environment.Name)
 	body, err := JSONReader(environment)
@@ -94,7 +94,7 @@ func (e *EnvironmentService) Put(environment *Environment) (data *Environment, e
 
 // Get the versions of a cookbook for this environment from the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id19
+// Chef API docs: https://docs.chef.io/api_chef_server.html#environments-name-cookbooks
 func (e *EnvironmentService) ListCookbooks(name string, numVersions string) (data EnvironmentCookbookResult, err error) {
 	path := versionParams(fmt.Sprintf("environments/%s/cookbooks", name), numVersions)
 	err = e.client.magicRequestDecoder("GET", path, nil, &data)
@@ -107,8 +107,8 @@ func (e *EnvironmentService) ListCookbooks(name string, numVersions string) (dat
 // be present when the cookbook_versions attributes is specified for an environment
 // or when dependencies are specified by a cookbook.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id20
+// Chef API docs: https://docs.chef.io/api_chef_server.html#cookbooks
 
 // Get a list of cookbooks and cookbook versions that are available to the specified environment.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id21
+// Chef API docs: https://docs.chef.io/api_chef_server.html#environments-name-cookbooks

--- a/node.go
+++ b/node.go
@@ -36,7 +36,7 @@ func NewNode(name string) (node Node) {
 
 // List lists the nodes in the Chef server.
 //
-// Chef API docs: http://docs.opscode.com/api_chef_server.html#id25
+// Chef API docs: https://docs.chef.io/api_chef_server.html#nodes
 func (e *NodeService) List() (data map[string]string, err error) {
 	err = e.client.magicRequestDecoder("GET", "nodes", nil, &data)
 	return
@@ -44,7 +44,7 @@ func (e *NodeService) List() (data map[string]string, err error) {
 
 // Get gets a node from the Chef server.
 //
-// Chef API docs: http://docs.opscode.com/api_chef_server.html#id28
+// Chef API docs: https://docs.chef.io/api_chef_server.html#nodes-name
 func (e *NodeService) Get(name string) (node Node, err error) {
 	url := fmt.Sprintf("nodes/%s", name)
 	err = e.client.magicRequestDecoder("GET", url, nil, &node)
@@ -53,7 +53,7 @@ func (e *NodeService) Get(name string) (node Node, err error) {
 
 // Post creates a Node on the chef server
 //
-// Chef API docs: https://docs.getchef.com/api_chef_server.html#id39
+// Chef API docs: https://docs.chef.io/api_chef_server.html#nodes
 func (e *NodeService) Post(node Node) (data *NodeResult, err error) {
 	body, err := JSONReader(node)
 	if err != nil {
@@ -66,7 +66,7 @@ func (e *NodeService) Post(node Node) (data *NodeResult, err error) {
 
 // Put updates a node on the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id42
+// Chef API docs: https://docs.chef.io/api_chef_server.html#nodes-name
 func (e *NodeService) Put(n Node) (node Node, err error) {
 	url := fmt.Sprintf("nodes/%s", n.Name)
 	body, err := JSONReader(n)
@@ -80,7 +80,7 @@ func (e *NodeService) Put(n Node) (node Node, err error) {
 
 // Delete removes a node on the Chef server
 //
-// Chef API docs: https://docs.getchef.com/api_chef_server.html#id40
+// Chef API docs: https://docs.chef.io/api_chef_server.html#nodes-name
 func (e *NodeService) Delete(name string) (err error) {
 	err = e.client.magicRequestDecoder("DELETE", "nodes/"+name, nil, nil)
 	return

--- a/principal.go
+++ b/principal.go
@@ -25,7 +25,7 @@ func NewPrincipal(name, typ, publicKey string) Principal {
 
 // Get gets a principal from the Chef server.
 //
-// Chef API docs: https://docs.chef.io/api_chef_server.html#id64
+// Chef API docs: https://docs.chef.io/api_chef_server.html#principals-name
 func (e *PrincipalService) Get(name string) (principal Principal, err error) {
 	url := fmt.Sprintf("principals/%s", name)
 	err = e.client.magicRequestDecoder("GET", url, nil, &principal)

--- a/role.go
+++ b/role.go
@@ -32,7 +32,7 @@ func (e RoleCreateResult) String() (out string) {
 
 // List lists the roles in the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id31
+// Chef API docs: https://docs.chef.io/api_chef_server.html#roles
 func (e *RoleService) List() (data *RoleListResult, err error) {
 	err = e.client.magicRequestDecoder("GET", "roles", nil, &data)
 	return
@@ -40,7 +40,7 @@ func (e *RoleService) List() (data *RoleListResult, err error) {
 
 // Create a new role in the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id32
+// Chef API docs: https://docs.chef.io/api_chef_server.html#roles
 func (e *RoleService) Create(role *Role) (data *RoleCreateResult, err error) {
 	// err = e.client.magicRequestDecoder("POST", "roles", role, &data)
 	body, err := JSONReader(role)
@@ -61,7 +61,7 @@ func (e *RoleService) Create(role *Role) (data *RoleCreateResult, err error) {
 
 // Delete a role from the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id33
+// Chef API docs: https://docs.chef.io/api_chef_server.html#roles-name
 func (e *RoleService) Delete(name string) (err error) {
 	path := fmt.Sprintf("roles/%s", name)
 	err = e.client.magicRequestDecoder("DELETE", path, nil, nil)
@@ -70,7 +70,7 @@ func (e *RoleService) Delete(name string) (err error) {
 
 // Get gets a role from the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id34
+// Chef API docs: https://docs.chef.io/api_chef_server.html#roles-name
 func (e *RoleService) Get(name string) (data *Role, err error) {
 	path := fmt.Sprintf("roles/%s", name)
 	err = e.client.magicRequestDecoder("GET", path, nil, &data)
@@ -79,7 +79,7 @@ func (e *RoleService) Get(name string) (data *Role, err error) {
 
 // Update a role in the Chef server.
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id35
+// Chef API docs: https://docs.chef.io/api_chef_server.html#roles-name
 func (e *RoleService) Put(role *Role) (data *Role, err error) {
 	path := fmt.Sprintf("roles/%s", role.Name)
 	//  err = e.client.magicRequestDecoder("PUT", path, role, nil)
@@ -97,10 +97,10 @@ func (e *RoleService) Put(role *Role) (data *Role, err error) {
 	return
 }
 
-// Get a list of environments have have environment specific run-lists for the given role
+// Get a list of environments that have environment specific run-lists for the given role
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id36
+// Chef API docs: https://docs.chef.io/api_chef_server.html#roles-name-environments
 
 // Get the environment-specific run-list for  a role
 //
-// Chef API docs: http://docs.getchef.com/api_chef_server.html#id37
+// Chef API docs: https://docs.chef.io/api_chef_server.html#roles-name-environments-name


### PR DESCRIPTION
There were some links to http://docs.opscode.com/api_chef_server.html#id5 in there, which gives a 404.

This also changes the hashes from `idN` to names of the API endpoints, like `#clients`. The links now don't go to the exact HTTP method anymore, so you'll have to scroll down a little bit to find the documentation, but hopefully the links are now a bit more stable (some existing links were already broken).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-chef/chef/92)
<!-- Reviewable:end -->
