### PR TITLE
Prevent showing the private key in the error

### DIFF
--- a/http.go
+++ b/http.go
@@ -312,7 +312,7 @@ func (ac AuthConfig) SignRequest(request *http.Request) error {
 func PrivateKeyFromString(key []byte) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(key)
 	if block == nil {
-		return nil, fmt.Errorf("block size invalid for '%s'", string(key))
+		return nil, fmt.Errorf("private key block size invalid")
 	}
 	rsaKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {


### PR DESCRIPTION
Depending on how and where this package is used, this could leak the key to the user. In our case this means it can leak a key that is not owned by the calling user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-chef/chef/97)
<!-- Reviewable:end -->
