### PR TITLE
Adding node policy_name and policy_group attributes

### DIFF
--- a/node.go
+++ b/node.go
@@ -17,6 +17,8 @@ type Node struct {
 	OverrideAttributes  map[string]interface{} `json:"override,omitempty"`
 	JsonClass           string                 `json:"json_class,omitempty"`
 	RunList             []string               `json:"run_list,omitempty"`
+	PolicyName          string                 `json:"policy_name,omitempty"`
+	PolicyGroup         string                 `json:"policy_group,omitempty"`
 }
 
 type NodeResult struct {


### PR DESCRIPTION
This doesn't implement the `/policies` or `/policy_groups` endpoints (which i might add later), just the node association attributes.

(Related to https://github.com/terraform-providers/terraform-provider-chef/issues/6)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-chef/chef/98)
<!-- Reviewable:end -->
