### PR TITLE
Use type int for Config Timeout

### DIFF
--- a/http.go
+++ b/http.go
@@ -67,7 +67,7 @@ type Config struct {
 	SkipSSL bool
 
 	// Time to wait in seconds before giving up on a request to the server
-	Timeout time.Duration
+	Timeout int
 }
 
 /*
@@ -146,7 +146,7 @@ func NewClient(cfg *Config) (*Client, error) {
 		},
 		client: &http.Client{
 			Transport: tr,
-			Timeout:   cfg.Timeout * time.Second,
+			Timeout:   time.Duration(cfg.Timeout) * time.Second,
 		},
 		BaseURL: baseUrl,
 	}


### PR DESCRIPTION
The library expects the given `Timeout` attribute to be set in seconds
and will multiply the value with `time.Second`, but uses the type
time.Duration. The `time.Duration` value is treated as nanoseconds
though. If the library expects the value in seconds, it should use an
appropriate type for that.

---

I was wondering why my timeout didn't work, until I realized that the resulting timeout was `10 * time.Second * time.Second`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-chef/chef/100)
<!-- Reviewable:end -->
