### PR TITLE
Fix formatting directives in tests

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -558,7 +558,7 @@ func TestDo_badjson(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/hashrocket", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, " pigthrusters => 100% ")
+		fmt.Fprintf(w, " pigthrusters => 100%% ")
 	})
 
 	stupidData := struct{}{}

--- a/node_test.go
+++ b/node_test.go
@@ -107,7 +107,7 @@ func TestNodesService_Methods(t *testing.T) {
 	// test Put
 	putRes, err := client.Nodes.Put(node)
 	if err != nil {
-		t.Errorf("Nodes.Put returned error", err)
+		t.Error("Nodes.Put returned error", err)
 	}
 
 	if !reflect.DeepEqual(putRes, node) {
@@ -117,6 +117,6 @@ func TestNodesService_Methods(t *testing.T) {
 	// test Delete
 	err = client.Nodes.Delete(node.Name)
 	if err != nil {
-		t.Errorf("Nodes.Delete returned error", err)
+		t.Error("Nodes.Delete returned error", err)
 	}
 }

--- a/principal_test.go
+++ b/principal_test.go
@@ -21,17 +21,17 @@ func TestPrincipalsGet(t *testing.T) {
 
 	p, err := client.Principals.Get("client_node")
 	if err != nil {
-		t.Errorf("GET principal error making request: ", err)
+		t.Error("GET principal error making request: ", err)
 		return
 	}
 
 	if p.Name != "client_node" {
-		t.Errorf("Unexpected principal name: ", p.Name)
+		t.Error("Unexpected principal name: ", p.Name)
 	}
 	if p.Type != "client" {
-		t.Errorf("Unexpected principal type: ", p.Type)
+		t.Error("Unexpected principal type: ", p.Type)
 	}
 	if p.PublicKey != "-----BEGIN PUBLIC KEY-----No, not really-----END PUBLIC KEY-----" {
-		t.Errorf("Unexpected principal public key: ", p.PublicKey)
+		t.Error("Unexpected principal public key: ", p.PublicKey)
 	}
 }

--- a/sandbox_test.go
+++ b/sandbox_test.go
@@ -51,7 +51,7 @@ func TestSandboxesPost(t *testing.T) {
 	// post the new sums/files to the sandbox
 	_, err := client.Sandboxes.Post(sums)
 	if err != nil {
-		t.Errorf("Snadbox Post error making request: ", err)
+		t.Error("Snadbox Post error making request: ", err)
 	}
 }
 
@@ -76,7 +76,7 @@ func TestSandboxesPut(t *testing.T) {
 
 	sandbox, err := client.Sandboxes.Put("f1c560ccb472448e9cfb31ff98134247")
 	if err != nil {
-		t.Errorf("Snadbox Put error making request: ", err)
+		t.Error("Snadbox Put error making request: ", err)
 	}
 
 	expected := Sandbox{

--- a/search_test.go
+++ b/search_test.go
@@ -60,30 +60,30 @@ func TestSearch_ExecDo(t *testing.T) {
 	// test the fail case
 	_, err := client.Search.NewQuery("foo", "failsauce")
 	if err == nil {
-		t.Errorf("Bad query wasn't caught")
+		t.Error("Bad query wasn't caught")
 	}
 
 	// test the fail case
 	_, err = client.Search.Exec("foo", "failsauce")
 	if err == nil {
-		t.Errorf("Bad query wasn't caught")
+		t.Error("Bad query wasn't caught")
 	}
 
 	// test the positive case
 	query, err := client.Search.NewQuery("nodes", "name:latte")
 	if err != nil {
-		t.Errorf("failed to create query")
+		t.Error("failed to create query")
 	}
 
 	// for now we aren't testing the result..
 	_, err = query.Do(client)
 	if err != nil {
-		t.Errorf("Search.Exec failed", err)
+		t.Error("Search.Exec failed", err)
 	}
 
 	_, err = client.Search.Exec("nodes", "name:latte")
 	if err != nil {
-		t.Errorf("Search.Exec failed", err)
+		t.Error("Search.Exec failed", err)
 	}
 
 }


### PR DESCRIPTION
This is to fix the following test failures which are reported in Go `1.11.5`:

```
$ go test ./...
# github.com/go-chef/chef
./http_test.go:561: Fprintf format %  is missing verb at end of string
./node_test.go:110: T.Errorf call has arguments but no formatting directives
./node_test.go:120: T.Errorf call has arguments but no formatting directives
./principal_test.go:24: T.Errorf call has arguments but no formatting directives
./principal_test.go:29: T.Errorf call has arguments but no formatting directives
./principal_test.go:32: T.Errorf call has arguments but no formatting directives
./principal_test.go:35: T.Errorf call has arguments but no formatting directives
./sandbox_test.go:54: T.Errorf call has arguments but no formatting directives
./sandbox_test.go:79: T.Errorf call has arguments but no formatting directives
./search_test.go:81: T.Errorf call has arguments but no formatting directives
./search_test.go:86: T.Errorf call has arguments but no formatting directives
FAIL	github.com/go-chef/chef [build failed]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-chef/chef/103)
<!-- Reviewable:end -->
