### PR TITLE
One more fix for go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chef/go-chef
+module github.com/go-chef/chef
 
 go 1.12
 


### PR DESCRIPTION
Looks like it was still a bit messed up. I suppose I could have just made a PR myself earlier, although I didn't actually notice this myself. I'll leave running `go mod tidy` to others just in case, because at least when I ran it it ignored the examples directory and was going to yank out a couple of packages only used in examples. 

* The module name in go.mod sadly refers to the chef fork