### PR TITLE
Adding members to groups does not use the group create structure

### DIFF
--- a/group.go
+++ b/group.go
@@ -65,8 +65,6 @@ func (e *GroupService) Create(group Group) (data *GroupResult, err error) {
 // Update a group on the Chef server.
 //
 // Chef API docs: https://docs.chef.io/api_chef_server.html#groups
-// Should this be name and group attributes?  We might want to be
-// able to change the name.
 func (e *GroupService) Update(g GroupUpdate) (group GroupUpdate, err error) {
 	url := fmt.Sprintf("groups/%s", g.Name)
 	body, err := JSONReader(g)

--- a/group.go
+++ b/group.go
@@ -17,6 +17,17 @@ type Group struct {
 	Users     []string `json:"users"`
 }
 
+// GroupUpdate represents the payload needed to update a group
+type GroupUpdate struct {
+	Name      string `json:"name"`
+	GroupName string `json:"groupname"`
+	Actors    struct {
+		Clients []string `json:"clients"`
+		Groups  []string `json:"groups"`
+		Users   []string `json:"users"`
+	} `json:"actors"`
+}
+
 type GroupResult struct {
 	Uri string `json:"uri"`
 }
@@ -56,7 +67,7 @@ func (e *GroupService) Create(group Group) (data *GroupResult, err error) {
 // Chef API docs: https://docs.chef.io/api_chef_server.html#groups
 // Should this be name and group attributes?  We might want to be
 // able to change the name.
-func (e *GroupService) Update(g Group) (group Group, err error) {
+func (e *GroupService) Update(g GroupUpdate) (group GroupUpdate, err error) {
 	url := fmt.Sprintf("groups/%s", g.Name)
 	body, err := JSONReader(g)
 	if err != nil {

--- a/group_test.go
+++ b/group_test.go
@@ -48,15 +48,25 @@ func TestGroupsService_Methods(t *testing.T) {
 	mux.HandleFunc("/groups/group3", func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		// TODO: Add true test for PUT, updating an existing value.
-		case r.Method == "GET" || r.Method == "PUT":
+		case r.Method == "GET":
 			fmt.Fprintf(w, `{
-                "name": "group3",
-                "groupname": "group3",
-                "orgname": "Test Org, LLC",
-                "actors": ["tester"],
-                "clients": ["tester"],
-                "groups": ["nested-group"]
-            }`)
+               		"name": "group3",
+                	"groupname": "group3",
+                	"orgname": "Test Org, LLC",
+                	"actors": ["tester"],
+                	"clients": ["tester"],
+                	"groups": ["nested-group"]
+            		}`)
+		case r.Method == "PUT":
+			fmt.Fprintf(w, `{
+                	"name": "group3",
+                	"groupname": "group3",
+                	"actors": {
+                		"clients": [],
+                		"groups": [],
+                		"users": ["tester2"]
+			}
+            		}`)
 		case r.Method == "DELETE":
 		}
 	})
@@ -104,14 +114,17 @@ func TestGroupsService_Methods(t *testing.T) {
 	// test Update
 	groupupdate := GroupUpdate{}
 	groupupdate.Name = "group3"
+	groupupdate.GroupName = "group3"
+	groupupdate.Actors.Clients = []string{}
+	groupupdate.Actors.Groups = []string{}
 	groupupdate.Actors.Users = []string{"tester2"}
 	updateRes, err := client.Groups.Update(groupupdate)
 	if err != nil {
-		t.Errorf("Groups.Update returned error: %v", err)
+		t.Errorf("Groups Update returned error %v", err)
 	}
 
-	if !reflect.DeepEqual(updateRes, group) {
-		t.Errorf("Groups.Update returned %+v, want %+v", updateRes, group)
+	if !reflect.DeepEqual(updateRes, groupupdate) {
+		t.Errorf("Groups Update returned %+v, want %+v", updateRes, groupupdate)
 	}
 
 	// test Delete

--- a/group_test.go
+++ b/group_test.go
@@ -102,7 +102,10 @@ func TestGroupsService_Methods(t *testing.T) {
 	}
 
 	// test Update
-	updateRes, err := client.Groups.Update(group)
+	groupupdate := GroupUpdate{}
+	groupupdate.Name = "group3"
+	groupupdate.Actors.Users = []string{"tester2"}
+	updateRes, err := client.Groups.Update(groupupdate)
 	if err != nil {
 		t.Errorf("Groups.Update returned error: %v", err)
 	}

--- a/test_chef_server/test/integration/default/inspec/group_spec.rb
+++ b/test_chef_server/test/integration/default/inspec/group_spec.rb
@@ -9,7 +9,10 @@ describe command('/go/src/testapi/bin/group') do
   its('stdout') { should match(%r{^Added group1 \&\{https://testhost/organizations/test/groups/group1\}}) }
   its('stdout') { should match(%r{^List groups after adding group1 map\[(?=.*group1:https://testhost/organizations/test/groups/group1)(?=.*admins:https://testhost/organizations/test/groups/admins)(?=.*billing-admins:https://testhost/organizations/test/groups/billing-admins)(?=.*clients:https://testhost/organizations/test/groups/clients)(?=.*users:https://testhost/organizations/test/groups/users)(?=.*public_key_read_access:https://testhost/organizations/test/groups/public_key_read_access).*\]EndAddList}) }
   its('stdout') { should match(/^Get group1 \{Name:group1 GroupName:group1 OrgName:test Actors:\[\] Clients:\[\] Groups:\[\] Users:\[\]\}/) }
-  its('stdout') { should match(/^Update group1 \{Name:group1 GroupName:group1-new OrgName: Actors:\[\] Clients:\[\] Groups:\[\] Users:\[pivotal\]\}/) }
+  its('stdout') { should match(/^Update group1 \{Name:group1 GroupName:group1 Actors:\{Clients:\[\] Groups:\[\] Users:\[pivotal\]\}\}/) }
+  its('stdout') { should match(/^Get group1 after update \{Name:group1 GroupName:group1 OrgName:test Actors:\[pivotal\] Clients:\[\] Groups:\[\] Users:\[pivotal\]\}/) }
+  its('stdout') { should match(/^Update group1 \{Name:group1 GroupName:group1-new Actors:\{Clients:\[\] Groups:\[admins\] Users:\[\]\}\}/) }
+  its('stdout') { should match(/^Get group1-new after update \{Name:group1-new GroupName:group1-new OrgName:test Actors:\[\] Clients:\[\] Groups:\[admins\] Users:\[\]\}/) }
   its('stdout') { should match(/^Delete group1 <nil>/) }
   its('stdout') { should match(%r{^List groups after cleanup map\[(?=.*admins:https://testhost/organizations/test/groups/admins)(?=.*billing-admins:https://testhost/organizations/test/groups/billing-admins)(?=.*clients:https://testhost/organizations/test/groups/clients)(?=.*users:https://testhost/organizations/test/groups/users)(?=.*public_key_read_access:https://testhost/organizations/test/groups/public_key_read_access).*\]EndFinalList}) }
 end

--- a/testapi/group.go
+++ b/testapi/group.go
@@ -68,13 +68,44 @@ func Group() {
 	fmt.Println("Get nothere", groupOutMissing)
 
 	// Update a group
-	group1.GroupName = "group1-new"
-	group1.Users = append(group1.Users, "pivotal")
-	groupUpdate, err := client.Groups.Update(group1)
+	groupupdate := chef.GroupUpdate{}
+	groupupdate.Name = "group1"
+	groupupdate.GroupName = "group1"
+	groupupdate.Actors.Clients = groupOut.Clients
+	groupupdate.Actors.Groups = []string{}
+	groupupdate.Actors.Users = []string{"pivotal"}
+	groupUpOut, err := client.Groups.Update(groupupdate)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Issue updating group1:", err)
 	}
-	fmt.Printf("Update group1 %+v\n", groupUpdate)
+	fmt.Printf("Update group1 %+v\n", groupUpOut)
+
+	// Get new group after update
+	groupOut, err = client.Groups.Get("group1")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Issue getting group1:", err)
+	}
+	fmt.Printf("Get group1 after update %+v\n", groupOut)
+
+	// Update a group add groups and change the group name
+	groupupdate = chef.GroupUpdate{}
+	groupupdate.Name = "group1"
+	groupupdate.GroupName = "group1-new"
+	groupupdate.Actors.Clients = []string{}
+	groupupdate.Actors.Groups = []string{"admins"}
+	groupupdate.Actors.Users = []string{}
+	groupUpOut, err = client.Groups.Update(groupupdate)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Issue updating group1:", err)
+	}
+	fmt.Printf("Update group1 %+v\n", groupUpOut)
+
+	// Get new group after update and rename
+	groupOut, err = client.Groups.Get("group1-new")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Issue getting group1-new:", err)
+	}
+	fmt.Printf("Get group1-new after update %+v\n", groupOut)
 
 	// Clean up
 	err = client.Groups.Delete("group1-new")

--- a/testapi/stats.go
+++ b/testapi/stats.go
@@ -12,7 +12,7 @@ import (
 func Stats() {
 	// Create a client for access
 	client := Client()
-	password  := os.Args[6]
+	password := os.Args[6]
 
 	stats, err := client.Stats.Get("statsuser", password)
 	if err != nil {


### PR DESCRIPTION
Adding members to groups uses a different JSON body.
Creating a group with members doesn't appear to work.
The current procedure is to create the group and then
update the group with the clients, groups and users desired.