### PR TITLE
Chef server returns a 400 if env_run_lists is null in JSON body

### DIFF
--- a/role.go
+++ b/role.go
@@ -12,7 +12,7 @@ type Role struct {
 	ChefType           string      `json:"chef_type,omitempty"`
 	DefaultAttributes  interface{} `json:"default_attributes,omitempty"`
 	Description        string      `json:"description"`
-	EnvRunList         EnvRunList  `json:"env_run_lists"`
+	EnvRunList         EnvRunList  `json:"env_run_lists,omitempty"`
 	JsonClass          string      `json:"json_class,omitempty"`
 	OverrideAttributes interface{} `json:"override_attributes,omitempty"`
 	RunList            RunList     `json:"run_list"`


### PR DESCRIPTION
I was getting a 400 back while trying to make the Terraform tests green on my fork of the Chef provider.  Changing this to omitempty makes the tests green.  It appears the Chef server does not like the null value.

Ref: https://github.com/bdwyertech/terraform-provider-chef/runs/5293000251?check_suite_focus=true#step:5:33

### BAD
```json
{
  "name": "terraform-acc-test-basic",
  "chef_type": "role",
  "default_attributes": {
    "terraform_acc_test": true
  },
  "description": "Terraform Acceptance Tests",
  "env_run_lists": null,
  "override_attributes": {
    "terraform_acc_test": true
  },
  "run_list": [
    "role[foo]"
  ]
}
```

### GOOD
```json
{
  "name": "terraform-acc-test-basic",
  "chef_type": "role",
  "default_attributes": {
    "terraform_acc_test": true
  },
  "description": "Terraform Acceptance Tests",
  "override_attributes": {
    "terraform_acc_test": true
  },
  "run_list": [
    "role[foo]"
  ]
}
```