### PR TITLE
adds response body back for re-use after Do is called

### DIFF
--- a/http.go
+++ b/http.go
@@ -442,6 +442,10 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	var resBuf bytes.Buffer
 	resTee := io.TeeReader(res.Body, &resBuf)
 
+	// add the body back to the response so
+	// subsequent calls to res.Body contain data
+	res.Body = ioutil.NopCloser(&resBuf)
+
 	// no response interface specified
 	if v == nil {
 		if debug_on() {


### PR DESCRIPTION
res.Body can only be read once currently. This PR puts it back so that it can be re-used by code that follows a call to the Do method.