### PR TITLE
ConfigProxy: Test the config proxy function [minor]

### DIFF
--- a/http.go
+++ b/http.go
@@ -226,6 +226,10 @@ func NewClient(cfg *Config) (*Client, error) {
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
 
+	if cfg.Proxy != nil {
+		tr.Proxy = cfg.Proxy
+	}
+
 	c := &Client{
 		Auth: &AuthConfig{
 			PrivateKey:            pk,


### PR DESCRIPTION
Add tests that verify the config proxy function.
There is some problem with http.ProxyFromEnvironment. It doesn't seem
to work in the test cases. Added a test that verifies the
function is specified. The return value when tested is nil though instead
of a url.