### PR TITLE
Fix parsing of gems in metadata.rb

### DIFF
--- a/cookbook.go
+++ b/cookbook.go
@@ -74,9 +74,9 @@ type CookbookMeta struct {
 	IssueUrl           string                 `json:"issues_url"`
 	ChefVersion        string
 	OhaiVersion        string
-	Gems               []string `json:"gems"`
-	EagerLoadLibraries bool     `json:"eager_load_libraries"`
-	Privacy            bool     `json:"privacy"`
+	Gems               [][]string `json:"gems"`
+	EagerLoadLibraries bool       `json:"eager_load_libraries"`
+	Privacy            bool       `json:"privacy"`
 }
 
 // CookbookAccess represents the permissions on a Cookbook
@@ -298,7 +298,7 @@ func metaSourceUrlParser(s []string, m *CookbookMeta) error {
 	return nil
 }
 func metaGemParser(s []string, m *CookbookMeta) error {
-	m.Gems = append(m.Gems, StringParserForMeta(s))
+	m.Gems = append(m.Gems, s)
 	return nil
 }
 


### PR DESCRIPTION
Hi!

Go-chef seems to break when it finds gem dependencies in `metadata.rb`. Both of the `gem` lines below are valid and should be supported (neither line works separately, either):

```
name 'example'
description 'An example cookbook'
maintainer 'Example maintainer'
maintainer_email 'maintainer@example.com'
license 'Apache-2.0'
version '1.0.5'
gem 'foobar'
gem 'aws-sdk-ec2', '~> 1.214.0'
```

The error from go-chef:

```
json: cannot unmarshal array into Go struct field CookbookMeta.metadata.gems of type string
```

The representation of the cookbook's metadata from `GET /organizations/NAME/cookbooks/NAME/VERSION` looks like:

```
"metadata": {
  "name": "example",
  "description": "An example cookbook",
  "maintainer": "Example maintainer",
  "maintainer_email": "maintainer@example.com",
  "license": "Apache-2.0",
  "platforms": {},
  "providing": {
	"example": ">= 0.0.0"
  },
  "recipes": {
	"example": ""
  },
  "version": "1.0.5",
  "source_url": "",
  "issues_url": "",
  "privacy": false,
  "chef_versions": [],
  "ohai_versions": [],
  "gems": [
	["foobar"],
	["aws-sdk-ec2", "~> 1.214.0"]
  ],
  "eager_load_libraries": true,
  "attributes": {},
  "dependencies": {},
  "long_description": ""
}
```

I haven't been able to find an example of the Chef API simply returning an array of strings, but if some ancient version of Chef did and it needs to be supported, we could handle it as an `[]interface{}`.

Originally discovered in https://github.com/drewhammond/chefbrowser/issues/81