### PR TITLE
Allow overriding http-client

### DIFF
--- a/http.go
+++ b/http.go
@@ -99,6 +99,9 @@ type Config struct {
 
 	// Proxy function to be used when making requests
 	Proxy func(*http.Request) (*url.URL, error)
+
+	// Pointer to an HTTP Client to use instead of the default
+	Client *http.Client
 }
 
 /*
@@ -239,11 +242,16 @@ func NewClient(cfg *Config) (*Client, error) {
 			ClientName:            cfg.Name,
 			AuthenticationVersion: cfg.AuthenticationVersion,
 		},
-		client: &http.Client{
+		BaseURL: baseUrl,
+	}
+
+	if cfg.Client != nil {
+		c.client = cfg.Client
+	} else {
+		c.client = &http.Client{
 			Transport: tr,
 			Timeout:   time.Duration(cfg.Timeout) * time.Second,
-		},
-		BaseURL: baseUrl,
+		}
 	}
 	c.IsWebuiKey = cfg.IsWebuiKey
 	c.ACLs = &ACLService{client: c}


### PR DESCRIPTION
This allows you to optionally pass in your own http client.  In my case, some scenarios are performing bulk operations against a server for backup, restore or synchronization.  In this case, it makes sense to implement a retry mechanism.

```go
	crt := retryablehttp.NewClient()
	crt.RetryMax = 10
	// build a client
	chefClient, err = chef.NewClient(&chef.Config{
		Name:    CHEF_USR,
		Key:     string(CHEF_KEY),
		BaseURL: CHEF_URL,
		Client:  crt.StandardClient(),
	})
	if err != nil {
		log.Fatal(err)
	}
```