### PR TITLE
Update ACL service and documentation

### DIFF
--- a/acl.go
+++ b/acl.go
@@ -6,24 +6,29 @@ type ACLService struct {
 	client *Client
 }
 
-//TODO: No ACL endpoints are documented
 // ACL represents the native Go version of the deserialized ACL type
 type ACL map[string]ACLitems
 
 // ACLitems
+//
+// Newer versions of the Chef server split Actors into Users and Clients.
 type ACLitems struct {
-	Groups ACLitem `json:"groups"`
-	Actors ACLitem `json:"actors"`
+	Groups  ACLitem `json:"groups"`
+	Actors  ACLitem `json:"actors"`
+	Users   ACLitem `json:"users"`
+	Clients ACLitem `json:"clients"`
 }
 
 // ACLitem
 type ACLitem []string
 
-func NewACL(acltype string, actors, groups ACLitem) (acl *ACL) {
+func NewACL(acltype string, actors, groups ACLitem, users ACLitem, clients ACLitem) (acl *ACL) {
 	acl = &ACL{
 		acltype: ACLitems{
 			Actors: actors,
 			Groups: groups,
+			Users: users,
+			Clients: clients,
 		},
 	}
 	return
@@ -31,18 +36,35 @@ func NewACL(acltype string, actors, groups ACLitem) (acl *ACL) {
 
 // Get gets an ACL from the Chef server.
 //
-// Chef API docs: lol
+// Warning: This API is not included in the Chef documentation and thus probably not officially supported.
+// Package documentation is based on the `knife` source code and packet capture.
+// It could be wrong or change in future Chef server updates.
+//
+// Subkind can be one of: clients, containers, cookbook_artifacts, cookbooks, data, environments, groups, nodes, roles, policies, policy_groups.
+//
+// Returns the ACL for multiple perms (create, read, update, delete, grant).
+// Older versions of the Chef server only include ACLs for "groups" and "actors."
+// If you're using a more recent version then the contents of "actors" is split up in "users" and "clients."
 func (a *ACLService) Get(subkind string, name string) (acl ACL, err error) {
-	url := fmt.Sprintf("%s/%s/_acl", subkind, name)
+	url := fmt.Sprintf("%s/%s/_acl?detail=granular", subkind, name)
 	err = a.client.magicRequestDecoder("GET", url, nil, &acl)
 	return
 }
 
 // Put updates an ACL on the Chef server.
 //
-// Chef API docs: rofl
-func (a *ACLService) Put(subkind, name string, acltype string, item *ACL) (err error) {
-	url := fmt.Sprintf("%s/%s/_acl/%s", subkind, name, acltype)
+// Warning: This API is not included in the Chef documentation and thus probably not officially supported.
+// Package documentation is based on the `knife` source code and packet capture.
+// It could be wrong or change in future Chef server updates.
+//
+// To change an ACL you have to fetch it from the Chef server first, as it expects the PUT request to
+// contain the same elements as the GET response. While the GET response returns ACLs for all perms, you have
+// to update each one separately.
+//
+// On newer versions of the Chef server you may need to replace "actors" with an empty list. Looks like the
+// actors list is only included for backwards compatibility but can't be in the PUT request.
+func (a *ACLService) Put(subkind, name string, perm string, item *ACL) (err error) {
+	url := fmt.Sprintf("%s/%s/_acl/%s", subkind, name, perm)
 	body, err := JSONReader(item)
 	if err != nil {
 		return

--- a/acl_test.go
+++ b/acl_test.go
@@ -22,6 +22,12 @@ func TestACLService_Get(t *testing.T) {
           "clients",
           "users",
           "admins"
+        ],
+        "users": [
+          "pivotal"
+        ],
+        "clients": [
+          "hostname"
         ]
       },
       "read": {
@@ -33,6 +39,12 @@ func TestACLService_Get(t *testing.T) {
           "clients",
           "users",
           "admins"
+        ],
+        "users": [
+          "pivotal"
+        ],
+        "clients": [
+          "hostname"
         ]
       },
       "update": {
@@ -43,6 +55,12 @@ func TestACLService_Get(t *testing.T) {
         "groups": [
           "users",
           "admins"
+        ],
+        "users": [
+          "pivotal"
+        ],
+        "clients": [
+          "hostname"
         ]
       },
       "delete": {
@@ -53,6 +71,12 @@ func TestACLService_Get(t *testing.T) {
         "groups": [
           "users",
           "admins"
+        ],
+        "users": [
+          "pivotal"
+        ],
+        "clients": [
+          "hostname"
         ]
       },
       "grant": {
@@ -62,6 +86,12 @@ func TestACLService_Get(t *testing.T) {
         ],
         "groups": [
           "admins"
+        ],
+        "users": [
+          "pivotal"
+        ],
+        "clients": [
+          "hostname"
         ]
       }
     }
@@ -74,11 +104,11 @@ func TestACLService_Get(t *testing.T) {
 	}
 
 	want := ACL{
-		"create": ACLitems{Groups: []string{"clients", "users", "admins"}, Actors: []string{"hostname", "pivotal"}},
-		"read":   ACLitems{Groups: []string{"clients", "users", "admins"}, Actors: []string{"hostname", "pivotal"}},
-		"update": ACLitems{Groups: []string{"users", "admins"}, Actors: []string{"hostname", "pivotal"}},
-		"delete": ACLitems{Groups: []string{"users", "admins"}, Actors: []string{"hostname", "pivotal"}},
-		"grant":  ACLitems{Groups: []string{"admins"}, Actors: []string{"hostname", "pivotal"}},
+		"create": ACLitems{Groups: []string{"clients", "users", "admins"}, Actors: []string{"hostname", "pivotal"}, Users: []string{"pivotal"}, Clients: []string{"hostname"}},
+		"read":   ACLitems{Groups: []string{"clients", "users", "admins"}, Actors: []string{"hostname", "pivotal"}, Users: []string{"pivotal"}, Clients: []string{"hostname"}},
+		"update": ACLitems{Groups: []string{"users", "admins"}, Actors: []string{"hostname", "pivotal"}, Users: []string{"pivotal"}, Clients: []string{"hostname"}},
+		"delete": ACLitems{Groups: []string{"users", "admins"}, Actors: []string{"hostname", "pivotal"}, Users: []string{"pivotal"}, Clients: []string{"hostname"}},
+		"grant":  ACLitems{Groups: []string{"admins"}, Actors: []string{"hostname", "pivotal"}, Users: []string{"pivotal"}, Clients: []string{"hostname"}},
 	}
 
 	if !reflect.DeepEqual(acl, want) {
@@ -94,7 +124,7 @@ func TestACLService_Put(t *testing.T) {
 		fmt.Fprintf(w, ``)
 	})
 
-	acl := NewACL("create", []string{"pivotal"}, []string{"admins"})
+	acl := NewACL("create", []string{"pivotal"}, []string{"admins"}, []string{"pivotal"}, []string{})
 	err := client.ACLs.Put("nodes", "hostname", "create", acl)
 	if err != nil {
 		t.Errorf("ACL.Put returned error: %v", err)

--- a/test_chef_server/test/integration/default/inspec/acl_spec.rb
+++ b/test_chef_server/test/integration/default/inspec/acl_spec.rb
@@ -1,0 +1,7 @@
+# Inspec tests for the ACL chef api go module
+#
+
+describe command('/go/src/testapi/bin/acl') do
+  its('stderr') { should_not match(/Issue/) }
+  its('stderr') { should_not match(/Expected/) }
+end

--- a/testapi/acl.go
+++ b/testapi/acl.go
@@ -1,0 +1,76 @@
+//
+// Test the go-chef/chef chef server api ACL endpoints against a live server
+//
+package testapi
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-chef/chef"
+)
+
+// ACL exercise the chef server api
+func ACL() {
+	client := Client()
+
+	node := chef.NewNode("acltest")
+	_, err := client.Nodes.Post(node)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Issue adding node for acl:", err)
+	}
+
+	// Create a new client and another chef.Client that uses its private key
+	newClient := chef.ApiNewClient{
+		Name:       "acltest",
+		ClientName: "acltest",
+		CreateKey:  true,
+	}
+	aclClient, err := client.Clients.Create(newClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Issue adding client for acl:", err)
+	}
+
+	// We want exactly the same test API client but with a different key.
+	client2 := Client()
+	client2.Auth.ClientName = "acltest"
+	private, err := chef.PrivateKeyFromString([]byte(aclClient.ChefKey.PrivateKey))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Issue creating private key from client create response:", err)
+	}
+	client2.Auth.PrivateKey = private
+
+	// Our new client shouldn't be allowed to delete our new node.
+	if err = client2.Nodes.Delete("acltest"); err == nil {
+		fmt.Fprintln(os.Stderr, "Expected error when deleting node without acl permission")
+	}
+
+	// Fetch existing ACL for our test node
+	acls, err := client.ACLs.Get("nodes", "acltest")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Issue fetching acls for node:", err)
+	}
+
+	// Modify the delete ACL to allow our test client to delete the node
+	acl, ok := acls["delete"]
+	if !ok {
+		fmt.Fprintln(os.Stderr, "Expected delete acl for node")
+	}
+	acl.Actors = []string{}
+	acl.Clients = append(acl.Clients, "acltest")
+	update := chef.ACL{"delete": acl}
+
+	if err = client.ACLs.Put("nodes", "acltest", "delete", &update); err != nil {
+		fmt.Fprintln(os.Stderr, "Issue updating acl for node:", err)
+	}
+
+	// Our new client should now be allowed to delete our new node.
+	if err = client2.Nodes.Delete("acltest"); err != nil {
+		fmt.Fprintln(os.Stderr, "Issue deleting node after setting acl:", err)
+	}
+
+	// Clean up
+	if err := client.Clients.Delete("acltest"); err != nil {
+		fmt.Fprintln(os.Stderr, "Issue deleting client for acl:", err)
+	}
+}

--- a/testapi/bin/acl
+++ b/testapi/bin/acl
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# ACL testing
+
+BASE=$(dirname $0)
+
+. ${BASE}/setup
+. ${BASE}/creds
+
+go run ${BASE}/../testcase/testcase.go acl ${CHEFUSER} ${KEYFILE} ${CHEFORGANIZATIONURL} ${SSLBYPASS}

--- a/testapi/testcase/testcase.go
+++ b/testapi/testcase/testcase.go
@@ -7,6 +7,7 @@ import (
 )
 
 var cases = map[string]func(){
+	"acl":                 testapi.ACL,
 	"association":         testapi.Association,
 	"association_cleanup": testapi.AssociationCleanup,
 	"association_setup":   testapi.AssociationSetup,


### PR DESCRIPTION
_This is a backwards incompatible change! As the previous code didn't work with the current version of Chef server, I guess it isn't used a lot. Let me know if you have suggestions to keep it backwards compatible._

These endpoints are [not included in the Chef documentation](https://docs.chef.io/server/api_chef_server/). Changes are based on the [source of `knife acl`](https://github.com/chef/chef/blob/4a54274d9c21bb9500989346d0d0ee22ba6076b3/knife/lib/chef/knife/acl_base.rb#L88) and packet captures between `knife`, `go-chef` and the Chef server.

I'm using the updated code like this:

```go
   name := "some-node.example.com"

   acls, err := client.ACLs.Get("nodes", name)
   if err != nil {
      log.Fatalln(err.Error())
   }

outer:
   for perm, acl := range acls {
      for i := range acl.Clients {
         if acl.Clients[i] == name {
            continue outer
         }
      }

      acl.Clients = append(acl.Clients, name)

      // We need to replace Actors with an empty list when updating.
      // Comments in the knife source code explain that this was used in older versions of the Chef server.
      // Newer versions use the separate groups, users and clients.
      //
      // The response contains Actors for backwards compat, but we can't update them.
      acl.Actors = []string{}

      put := chef.ACL{perm: acl}

      if err = client.ACLs.Put("nodes", name, perm, &put); err != nil {
         log.Fatalln(err.Error())
      }
   }
```