### PR TITLE
Override http.Client.Transport

### DIFF
--- a/http.go
+++ b/http.go
@@ -220,24 +220,6 @@ func NewClient(cfg *Config) (*Client, error) {
 
 	baseUrl, _ := url.Parse(cfg.BaseURL)
 
-	tlsConfig := &tls.Config{InsecureSkipVerify: cfg.SkipSSL}
-	if cfg.RootCAs != nil {
-		tlsConfig.RootCAs = cfg.RootCAs
-	}
-	tr := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).Dial,
-		TLSClientConfig:     tlsConfig,
-		TLSHandshakeTimeout: 10 * time.Second,
-	}
-
-	if cfg.Proxy != nil {
-		tr.Proxy = cfg.Proxy
-	}
-
 	c := &Client{
 		Auth: &AuthConfig{
 			PrivateKey:            pk,
@@ -250,6 +232,24 @@ func NewClient(cfg *Config) (*Client, error) {
 	if cfg.Client != nil {
 		c.client = cfg.Client
 	} else {
+		tlsConfig := &tls.Config{InsecureSkipVerify: cfg.SkipSSL}
+		if cfg.RootCAs != nil {
+			tlsConfig.RootCAs = cfg.RootCAs
+		}
+		tr := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			Dial: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).Dial,
+			TLSClientConfig:     tlsConfig,
+			TLSHandshakeTimeout: 10 * time.Second,
+		}
+
+		if cfg.Proxy != nil {
+			tr.Proxy = cfg.Proxy
+		}
+
 		c.client = &http.Client{
 			Transport: tr,
 			Timeout:   time.Duration(cfg.Timeout) * time.Second,


### PR DESCRIPTION
In #245, support was proposed for overriding the `http.Client`. However, I only want to modify the `http.Transport`, so I have to duplicate the entire `http.Client` configuration code inside my module, like so:

```
func newChefHttpClient(cfg *chef.Config) *chef.Config {
       // This is copied directly from go-chef/chef/http.go
       tlsConfig := &tls.Config{InsecureSkipVerify: cfg.SkipSSL}
       if cfg.RootCAs != nil {
               tlsConfig.RootCAs = cfg.RootCAs
       }
       tr := &http.Transport{
               Proxy: http.ProxyFromEnvironment,
               Dial: (&net.Dialer{
                       Timeout:   30 * time.Second,
                       KeepAlive: 30 * time.Second,
               }).Dial,
               TLSClientConfig:     tlsConfig,
               TLSHandshakeTimeout: 10 * time.Second,
       }

       if cfg.Proxy != nil {
               tr.Proxy = cfg.Proxy
       }

       cfg.Client = &http.Client{
               Transport: tr,
               Timeout:   time.Duration(cfg.Timeout) * time.Second,
       }

       return cfg
}
```

Then, I set the `cfg.Client.Transport` after calling this function.

This is brittle, because `go-chef/chef`'s implementation may change, and I'd like to get those changes too whenever the rest of the package is updated.

I'd prefer a way to set the `Transport` on the constructed `*http.Client`. However, I still need to be able to chain to the old `Transport`, for the same reason as above: I don't want to duplicate all the code to set `Proxy` `Dial` `TLSClientConfig` `TLSHandshakeTimeout`, and risk it drifting away from this implementation.

So I added the `Config` field `RoundTripper func(http.RoundTripper) http.RoundTripper` which can modify or replace the existing `Transport`.

I wrote tests similar to the `Client` tests from #246. They don't actually test whether the  override is used, only whether it is set.

## Alternate approaches

I don't know which approach is best, so I wrote a PR for you to help me decide. Please share your thoughts!

1. A `func` which modifies `http.Client.Transport`. (This PR).
1. A `func` which modifies `http.Client` - a caller could replace, save a pointer, or mutate the client at will, without being so tightly coupled to the `Transport` specifically.
1. Export `else { tlsConfig := .... c.client = &http.Client{ ... } }` code as a constructor function. The consumer can mutate/replace and pass it back as `cfg.Client`.
1. Export the `Client *http.Client` field on the `type Client struct`. (Why not? Every other field is exported!)